### PR TITLE
Add copilot-setup-steps.yml for Copilot coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,35 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          install-mode: binary


### PR DESCRIPTION
## Summary

Adds `.github/workflows/copilot-setup-steps.yml` so the Copilot coding agent's ephemeral GitHub Actions environment is pre-configured with:

- **Go** (version from `go.mod`)
- **Module dependencies** (`go mod download`)
- **golangci-lint** (binary install)

This eliminates trial-and-error dependency discovery and lets Copilot immediately build, test, and validate changes.

## Checklist from #18

- [x] `copilot-setup-steps.yml` created
- [ ] Workflow runs successfully when triggered manually (verify after merge)
- [ ] Copilot coding agent can build and test the project (verify after merge)

### Optional (not in this PR)
- [ ] Create `copilot` environment with Azure secrets for LLM eval tests
- [ ] Add path-specific instructions (`.github/instructions/*.instructions.md`)

Closes #18